### PR TITLE
add vendor and repository optional fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,14 @@ homepage = "https://github.com/cat-in-136/cargo-generate-rpm"
 readme = "README.md"
 keywords = ["rpm", "package", "cargo", "subcommand"]
 repository = "https://github.com/cat-in-136/cargo-generate-rpm"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 glob = "0.3.0"
-rpm = {git = "http://github.com/tofay/rpm-rs", branch = "no-bin-sh-requires" } 
+rpm = {git = "http://github.com/RocketJas/rpm-rs", branch = "no-bin-sh-requires" } 
 toml = "0.5"
 cargo_toml = "0.11"
 getopts = "0.2"
@@ -31,3 +31,7 @@ assets = [
     { source = "LICENSE", dest = "/usr/share/doc/cargo-generate-rpm/LICENSE", doc = true, mode = "0644" },
     { source = "README.md", dest = "/usr/share/doc/cargo-generate-rpm/README.md", doc = true, mode = "0644" }
 ]
+
+release = "dummy_release"
+vendor = "dummy vendor"
+repository = "dummy repository overide"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -156,6 +156,19 @@ impl Config {
             builder = builder.post_uninstall_script(post_uninstall_script);
         }
 
+
+        if let Some(repository) = match (metadata.get_str("repository")?, pkg.repository.as_ref()) {
+            (Some(v), _) => Some(v),
+            (None, None) => None,
+            (None, Some(v)) => Some(v.as_str()),
+        } {
+            builder = builder.repository(repository);
+        }
+
+        if let Some(vendor) = metadata.get_str("vendor")? {
+            builder = builder.vendor(vendor);
+        }
+
         if let Some(requires) = metadata.get_table("requires")? {
             for dependency in Self::table_to_dependencies(requires)? {
                 builder = builder.requires(dependency);


### PR DESCRIPTION
This is just a draft until `https://github.com/tofay/rpm-rs/pull/1` gets merged then rpm will point back to tofay repo.